### PR TITLE
arch-x86: Add `destSize` for AVX microop `vclear`

### DIFF
--- a/src/arch/x86/insts/static_inst.cc
+++ b/src/arch/x86/insts/static_inst.cc
@@ -121,9 +121,10 @@ namespace X86ISA
     X86StaticInst::printReg(std::ostream &os, RegId reg, int size) const
     {
         if (reg.isFloatReg()) {
-          // We allow xmm registers to have 128, 256 and 512.
+            // We allow xmm registers to have 128, 256 and 512.
             assert(size == 1 || size == 2 || size == 4 || size == 8 ||
-                   size == 16 || size == 32 || size == 64);
+                    size == 16 || size == 32 || size == 48 || size == 52 ||
+                    size == 64);
         } else {
             assert(size == 1 || size == 2 || size == 4 || size == 8);
         }

--- a/src/arch/x86/isa/microops/avxop.isa
+++ b/src/arch/x86/isa/microops/avxop.isa
@@ -174,6 +174,7 @@ let {{
             super(Vclear, self).__init__(
                 dest=dest,
                 destVL=destVL,
+                destSize=64 - destVL,
             )
         opClass = 'SimdMiscOp'
         srcType = 'AVXOpBase::SrcType::Non'
@@ -183,6 +184,7 @@ let {{
             assert(vRegs <= NumXMMSubRegs && "VL overflow.");
             _numDestRegs = NumXMMSubRegs - vRegs;
             assert(_numDestRegs <= MaxInstDestRegs && "DestRegs overflow.");
+            assert(NumXMMSubRegs == 8 && "We assume 64-byte zmm registers.");
             _numFPDestRegs = _numDestRegs;
             for (int i = 0; i < _numDestRegs; i++) {
                 setDestRegIdx(i, RegId(FloatRegClass, dest + i));


### PR DESCRIPTION
The `vclear`'s `destSize` is not assigned and takes a default value 0,
which can cause the failure in assertion when disassembling this
microop. The `destSize` now is initialized for the AVXOpBase with
`64 - destVL` to reflect the data size in terms of bits will be cleared
by `vclear`.

Fixes: #1 